### PR TITLE
Fix adagio list with etcd backend

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -112,8 +112,11 @@ func (r *Repository) ListRuns() (runs []*adagio.Run, err error) {
 	}
 
 	for _, kv := range resp.Kvs {
-		parts := strings.SplitN(r.ns.stripBytes(kv.Key), "/", 2)
-		if len(parts) < 2 {
+		parts := strings.Split(r.ns.stripBytes(kv.Key), "/")
+
+		// ignore malformed or output keys
+		// runs/<run_id>/nodes/<node_id>/output
+		if len(parts) < 2 || (len(parts) == 5 && parts[4] == "output") {
 			continue
 		}
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -75,14 +75,6 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 		require.Nil(t, err)
 		require.NotNil(t, run)
 
-		t.Run("which can be listed", func(t *testing.T) {
-			runs, err := repo.ListRuns()
-			require.Nil(t, err)
-
-			assert.Len(t, runs, 1)
-			assert.Equal(t, run.Id, runs[0].Id)
-		})
-
 		for _, layer := range []TestLayer{
 			{
 				// (›) ---> (c)----
@@ -193,6 +185,14 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 		} {
 			layer.Exec(t)
 		}
+
+		t.Run("which can be listed", func(t *testing.T) {
+			runs, err := repo.ListRuns()
+			require.Nil(t, err)
+
+			assert.Len(t, runs, 1)
+			assert.Equal(t, run.Id, runs[0].Id)
+		})
 	})
 }
 


### PR DESCRIPTION
Fixes #17 

This is a fix and adjustment to the test harness to capture a bug which caused output nodes stored in etcd to be reported as individual runs.

By moving the test of the list action to after the node progression tests the bug in the etcd repository implementation surfaces.

> requires a restart of adagiod to observe fix