### PR TITLE
Fix "conclusion not recognized" error in printing package

### DIFF
--- a/pkg/printing/print.go
+++ b/pkg/printing/print.go
@@ -118,6 +118,8 @@ func statusToString(state adagio.Node_Status) (string, error) {
 
 func conclusionToString(conclusion adagio.Conclusion) (string, error) {
 	switch conclusion {
+	case adagio.Conclusion_NONE:
+		return "none", nil
 	case adagio.Conclusion_SUCCESS:
 		return "success", nil
 	case adagio.Conclusion_FAIL:


### PR DESCRIPTION
This fixes a bug introduced by the addition of the `adagio.Conclusion_NONE` conclusion. This change introduces support for this conclusion into the printing package.