### PR TITLE
Fix graph: node not found errors when using etcd repository

### DIFF
--- a/pkg/etcd/doc.go
+++ b/pkg/etcd/doc.go
@@ -1,0 +1,15 @@
+// package etcd contains types which enable etcd as a repository backend for
+// the adagio workflow engine.
+//
+// Keyspace Design (etcd internals)
+//
+// Namespaces:
+// v0/runs/   : runs namespace
+// v0/states/ : states namespace
+//
+// Objects:
+// v0/runs/<run-id>                              : Run{}
+// v0/states/<state>/run/<run-id>/node/<node-id> : Node{}
+//
+// States: (waiting, ready, running, completed)
+package etcd

--- a/pkg/etcd/doc.go
+++ b/pkg/etcd/doc.go
@@ -8,8 +8,9 @@
 // v0/states/ : states namespace
 //
 // Objects:
-// v0/runs/<run-id>                              : Run{}
-// v0/states/<state>/run/<run-id>/node/<node-id> : Node{}
+// v0/runs/<run-id>                           : Run{}  serialized run object
+// v0/runs/<run-id>/node/<name>               : Node{} serialized node object
+// v0/states/<state>/run/<run-id>/node/<name> : ""     empty string to identify state
 //
 // States: (waiting, ready, running, completed)
 package etcd

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -567,10 +567,6 @@ func (n namespace) nodeInStateKey(runID, state, name string) string {
 	return fmt.Sprintf("%sstates/%s/run/%s/node/%s", n, state, runID, name)
 }
 
-func (n namespace) output(runID, node string) string {
-	return fmt.Sprintf("%sruns/%s/node/%s/output", n, runID, node)
-}
-
 func (n namespace) stripBytes(key []byte) string {
 	return strings.TrimPrefix(string(key), string(n))
 }


### PR DESCRIPTION
Due to a race in node collection when fetching nodes for a given run, nodes could appear missing. This is due to the fact the get nodes for run operation did 4 queries. One for each set of nodes in each state space.

While this was happening a node could switch states. For example:
1. worker A reads "ready" states keyspace for run "foo"
2. worker B moves node "bar" from "running" to "ready" because it failed but has retries
3. worker A ready "running" states keyspace for run "foo"

By the end of this operations worker A never is aware of node "bar" as it was swapped from under it as it read the keyspace.

Instead this change ensures all nodes exist and are serialized to a none-state prefixed keyspace under their respective run.
State keyspace is still used, however, just as a sentinal to mark node state for watchers and subscriptions. Also it will support lease of running when work undergoes to support automatic node recovery.