### PR TITLE
Refactor runtimes helper packages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - -backend-type=etcd
       - -etcd-addresses=http://etcd:2379
       - api
+    ports:
+      - "7890:7890"
     restart: always
   agent:
     build:

--- a/example/graph-with-error.json
+++ b/example/graph-with-error.json
@@ -2,27 +2,30 @@
   "nodes":[
     {
       "name":    "a",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "b",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "c",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "d",
-      "runtime": "error"
+      "runtime": "debug",
+      "metadata": {
+        "adagio.runtime.debug.conclusion": {"values": ["error"]}
+      }
     },
     {
       "name":    "e",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "f",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "g",

--- a/example/graph-with-failure.json
+++ b/example/graph-with-failure.json
@@ -2,27 +2,30 @@
   "nodes":[
     {
       "name":    "a",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "b",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "c",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "d",
-      "runtime": "fail"
+      "runtime": "debug",
+      "metadata": {
+        "adagio.runtime.debug.conclusion": {"values": ["fail"]}
+      }
     },
     {
       "name":    "e",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "f",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "g",

--- a/example/graph-with-flakey-runtime.json
+++ b/example/graph-with-flakey-runtime.json
@@ -2,30 +2,33 @@
   "nodes":[
     {
       "name":    "a",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "b",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "c",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "d",
-      "runtime": "flakey",
+      "runtime": "debug",
+      "metadata": {
+        "adagio.runtime.debug.chances": {"values": ["0.5 fail"]}
+      },
       "retry": {
         "fail": {"max_attempts": 3}
       }
     },
     {
       "name":    "e",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "f",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "g",

--- a/example/graph-with-panic.json
+++ b/example/graph-with-panic.json
@@ -2,30 +2,33 @@
   "nodes":[
     {
       "name":    "a",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "b",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "c",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "d",
-      "runtime": "panic",
+      "runtime": "debug",
+      "metadata": {
+        "adagio.runtime.debug.chances": {"values": ["0.5 panic"]}
+      },
       "retry": {
         "error": {"max_attempts": 3}
-       }
+      }
     },
     {
       "name":    "e",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "f",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "g",

--- a/example/graph.json
+++ b/example/graph.json
@@ -2,27 +2,27 @@
   "nodes":[
     {
       "name":    "a",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "b",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "c",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "d",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "e",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "f",
-      "runtime": "echo"
+      "runtime": "debug"
     },
     {
       "name":    "g",

--- a/pkg/adagio/node.go
+++ b/pkg/adagio/node.go
@@ -2,6 +2,18 @@ package adagio
 
 import "strings"
 
+// RetryCondition is a key used in the node spec retry map
+type RetryCondition string
+
+const (
+	// OnFail is the retry condition where a node results in a
+	// failure
+	OnFail RetryCondition = "fail"
+	// OnError is the retry condition where a node results in a
+	// system related error
+	OnError RetryCondition = "error"
+)
+
 // CanRetry returns true if the node can be retried
 func CanRetry(node *Node) (canRetry bool) {
 	VisitLatestAttempt(node, func(result *Node_Result) {

--- a/pkg/runtimes/debug/debug.go
+++ b/pkg/runtimes/debug/debug.go
@@ -1,0 +1,155 @@
+package debug
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/georgemac/adagio/pkg/adagio"
+	runtime "github.com/georgemac/adagio/pkg/runtimes"
+)
+
+// Call is a structure which contains the arguments
+// for a debug package runtime call
+type Call struct {
+	*runtime.Builder
+	Conclusion string
+	Sleep      int64
+	Chances    []string
+}
+
+// Option is a function option for the Call type
+type Option func(*Call)
+
+// Options is a slice of Option types
+type Options []Option
+
+// Apply calls each option in order on the provided Call
+func (o Options) Apply(c *Call) {
+	for _, opt := range o {
+		opt(c)
+	}
+}
+
+// WithSleep configures a sleep on the debug call
+func WithSleep(dur time.Duration) Option {
+	return func(c *Call) {
+		c.Sleep = int64(dur)
+	}
+}
+
+// Result is a string type which reprents the
+// result of an operation ran by debug runtime call
+type Result string
+
+const (
+	// Success is a successful result expectation
+	Success Result = "success"
+	// Fail is a failure result expectation
+	Fail Result = "fail"
+	// Error is an error result expectation
+	Error Result = "error"
+	// Panic is a system panic expecation
+	Panic Result = "panic"
+)
+
+// ChanceCondition is a structure which contains a
+// potential result for the debug call and a probability
+// represented as a float64 in the range [0, 1)
+type ChanceCondition struct {
+	Result      Result
+	Probability float64
+}
+
+// Chance configures a new ChanceCondition
+func Chance(prob float64, res Result) ChanceCondition {
+	return ChanceCondition{res, prob}
+}
+
+// With configures a set of ChanceConditions on a Call
+// when the option is invoked
+func With(chances ...ChanceCondition) Option {
+	return func(c *Call) {
+		for _, chance := range chances {
+			c.Chances = append(c.Chances, fmt.Sprintf("%.2f %s", chance.Probability, chance.Result))
+		}
+	}
+}
+
+// NewCall constructure and configures a new Call pointer
+// The call will result in the provided conclusion unless
+// one of zero or more chance conditions come true. In the
+// case a chance condition is true, the result within the
+// condition is made instead.
+//
+// e.g. With(Chance(0.5, Panic)) will result in the runtime
+// causing a panic 50% of the time
+func NewCall(conclusion adagio.Result_Conclusion, opts ...Option) *Call {
+	call := newCall()
+	call.Conclusion = strings.ToLower(conclusion.String())
+
+	Options(opts).Apply(call)
+
+	return call
+}
+
+func newCall() *Call {
+	c := &Call{Builder: runtime.NewBuilder("debug")}
+
+	c.String("conclusion", false, "success")(&c.Conclusion)
+	c.Int64("sleep", false, 0)(&c.Sleep)
+	c.Strings("chances", false)(&c.Chances)
+
+	return c
+}
+
+// Runtime is a struct which implements the worker.Runtime
+// It executes a specification for a debug task. This task
+// mostly reports back whatever it is told, along with sleeping
+// for a configured amount of time.
+type Runtime struct{}
+
+// NewRuntime configures and returns a new Runtime pointer
+func NewRuntime() *Runtime {
+	return &Runtime{}
+}
+
+// Run parse the debug run from the provided Node and then
+// invokes the desired operations. It first sleeps the configured ammount
+// and then loops over any provided chance conditions.
+// Given no chance condinition is met it returns the configured
+// adagio result conclusion
+func (r *Runtime) Run(n *adagio.Node) (*adagio.Result, error) {
+	call := newCall()
+	call.Parse(n.Spec)
+
+	time.Sleep(time.Duration(call.Sleep))
+
+	for _, c := range call.Chances {
+		var chance ChanceCondition
+		if _, err := fmt.Sscanf(c, "%f %s", &chance.Probability, &chance.Result); err != nil {
+			return nil, err
+		}
+
+		if rand.Float64() < chance.Probability {
+			switch chance.Result {
+			case Panic:
+				panic("uh oh")
+			case Error:
+				return nil, errors.New("debug: error condition")
+			default:
+				conclusion := strings.ToUpper(string(chance.Result))
+				return &adagio.Result{
+					Conclusion: adagio.Result_Conclusion(adagio.Result_Conclusion_value[conclusion]),
+				}, nil
+			}
+		}
+	}
+
+	conclusion := strings.ToUpper(call.Conclusion)
+	return &adagio.Result{
+		Conclusion: adagio.Result_Conclusion(adagio.Result_Conclusion_value[conclusion]),
+	}, nil
+}

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -3,17 +3,85 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/georgemac/adagio/pkg/adagio"
 )
 
-func Parse(spec *adagio.Node_Spec, fields ...Field) error {
-	for _, field := range fields {
-		name := fmt.Sprintf("adagio.runtime.%s", field.Name())
+// FieldType is a type of field
+type FieldType uint8
 
-		values, ok := spec.Metadata[name]
+// String prints a string representation of the field type
+func (t FieldType) String() string {
+	switch t {
+	case StringFieldType:
+		return "string"
+	case StringsFieldType:
+		return "[]string"
+	case Int64FieldType:
+		return "int64"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// StringFieldType represents a string type field
+	StringFieldType FieldType = iota
+	// StringsFieldType represents a slice of string types field
+	StringsFieldType
+	// Int64FieldType represents ant int64 type field
+	Int64FieldType
+)
+
+// Builder is a struct aids in both parsing and construction
+// of runtimes and runtime request types
+type Builder struct {
+	name   string
+	fields []*Field
+}
+
+// NewBuilder constructs and configures a new runtime builder
+func NewBuilder(name string) *Builder {
+	return &Builder{name: name}
+}
+
+// Name returns the name of the runtime being built
+func (p *Builder) Name() string {
+	return p.name
+}
+
+func (p *Builder) fieldName(field *Field) string {
+	return fmt.Sprintf("adagio.runtime.%s.%s", p.name, field.Name)
+}
+
+// Spec constructs a Node_Spec based on the current state
+// of the builders fields
+func (p *Builder) Spec() (*adagio.Node_Spec, error) {
+	spec := &adagio.Node_Spec{Runtime: p.name}
+	for _, field := range p.fields {
+		values, err := field.Values()
+		if err != nil {
+			return nil, err
+		}
+
+		if spec.Metadata == nil {
+			spec.Metadata = map[string]*adagio.MetadataValue{}
+		}
+
+		spec.Metadata[p.fieldName(field)] = &adagio.MetadataValue{Values: values}
+	}
+
+	return spec, nil
+}
+
+// Parse parses the state from a node spec into the targets
+// set on the builders fields
+func (p *Builder) Parse(spec *adagio.Node_Spec) error {
+	for _, field := range p.fields {
+		values, ok := spec.Metadata[p.fieldName(field)]
 		if !ok {
-			if field.Required() {
+			if field.Required {
 				return errors.New("key not found")
 			}
 
@@ -32,17 +100,32 @@ func Parse(spec *adagio.Node_Spec, fields ...Field) error {
 	return nil
 }
 
-type Spec struct {
-	Name string
-}
+// StringField is a function which takes a string pointer
+// and returns a Field pointers which will set and get from
+// the provided string pointer
+type StringField func(*string) *Field
 
-func NewSpec(name string) *Spec {
-	return &Spec{name}
-}
+// String configures a StringField which when call with a string pointer
+// will set the pointer on calls to builder.Parse() and read the value
+// at the end of the pointer on calls to builder.Spec()
+func (s *Builder) String(name string, required bool, defaultValue string) StringField {
+	field := newField(name, StringFieldType, required, []string{defaultValue})
+	s.fields = append(s.fields, field)
 
-func (s *Spec) String(name string, required bool, defaultValue string) StringField {
-	return func(v *string) Field {
-		return newField(fmt.Sprintf("%s.%s", s.Name, name), required, []string{defaultValue}, func(vs []string) error {
+	return func(v *string) *Field {
+		field.values = func() ([]string, error) {
+			if v == nil {
+				if required {
+					return nil, errors.New("field is required")
+				}
+
+				return nil, nil
+			}
+
+			return []string{*v}, nil
+		}
+
+		field.parse = func(vs []string) error {
 			if len(vs) < 1 {
 				return errors.New("no value set for key")
 			}
@@ -50,46 +133,126 @@ func (s *Spec) String(name string, required bool, defaultValue string) StringFie
 			*v = vs[0]
 
 			return nil
-		})
+		}
+
+		return field
 	}
 }
 
-func (s *Spec) Strings(name string, required bool, defaultValue []string) StringsField {
-	return func(v *[]string) Field {
-		return newField(fmt.Sprintf("%s.%s", s.Name, name), required, defaultValue, func(vs []string) error {
+// StringsField is a function which takes a slice of string pointer
+// and returns a Field pointers which will set and get from
+// the provided slice of string pointer
+type StringsField func(*[]string) *Field
+
+// Strings configures a StringsField which when call with a string slice pointer
+// will set the pointer on calls to builder.Parse() and read the value
+// at the end of the pointer on calls to builder.Spec()
+func (s *Builder) Strings(name string, required bool, defaultValues ...string) StringsField {
+	field := newField(name, StringsFieldType, required, defaultValues)
+	s.fields = append(s.fields, field)
+
+	return func(v *[]string) *Field {
+		field.values = func() ([]string, error) {
+			if v == nil {
+				if required {
+					return nil, errors.New("field is required")
+				}
+
+				return nil, nil
+			}
+
+			return *v, nil
+		}
+
+		field.parse = func(vs []string) error {
 			*v = vs
 
 			return nil
-		})
+		}
+
+		return field
 	}
 }
 
-type StringField func(*string) Field
+// Int64Field is a function which takes a int64 pointer
+// and returns a Field pointers which will set and get from
+// the provided pointer
+type Int64Field func(*int64) *Field
 
-type StringsField func(*[]string) Field
+// Int64 configures a Int64Field which when call with a int64 pointer
+// will set the pointer on calls to builder.Parse() and read the value
+// at the end of the pointer on calls to builder.Spec()
+func (s *Builder) Int64(name string, required bool, defaultValue int64) Int64Field {
+	field := newField(name, Int64FieldType, required, []string{fmt.Sprintf("%d", defaultValue)})
+	s.fields = append(s.fields, field)
 
-type Field struct {
-	name         string
-	required     bool
-	parse        func([]string) error
-	setToDefault func() error
+	return func(v *int64) *Field {
+		field.values = func() ([]string, error) {
+			if v == nil {
+				if required {
+					return nil, errors.New("field is required")
+				}
+
+				return nil, nil
+			}
+
+			return []string{fmt.Sprintf("%d", *v)}, nil
+		}
+
+		field.parse = func(vs []string) (err error) {
+			if len(vs) < 1 {
+				return errors.New("no value set for key")
+			}
+
+			*v, err = strconv.ParseInt(vs[0], 10, 64)
+
+			return err
+		}
+
+		return field
+	}
 }
 
-func (f Field) Name() string { return f.name }
+// Field is a structure which contains the properties
+// of a field used to call a runtime
+type Field struct {
+	Name     string
+	Type     FieldType
+	Required bool
+	Defaults []string
+	parse    func([]string) error
+	values   func() ([]string, error)
+}
 
-func (f Field) Required() bool { return f.required }
+// Values returns the fields value represented as a slice of strings
+// for use in node spec metadata
+func (f *Field) Values() ([]string, error) {
+	if f.values == nil {
+		return nil, fmt.Errorf("target not set for %q", f.Name)
+	}
 
-func (f Field) Parse(args []string) error { return f.parse(args) }
+	return f.values()
+}
 
-func (f Field) SetToDefault() error { return f.setToDefault() }
+// Parse sets the values of the field using the provided slice of strings
+func (f *Field) Parse(args []string) error {
+	if f.parse == nil {
+		return fmt.Errorf("target not set for %q", f.Name)
+	}
 
-func newField(name string, required bool, defaultValues []string, parse func([]string) error) Field {
-	return Field{
-		name:     name,
-		required: required,
-		parse:    parse,
-		setToDefault: func() error {
-			return parse(defaultValues)
-		},
+	return f.parse(args)
+}
+
+// SetToDefault applies the default values to the field
+func (f Field) SetToDefault() error {
+	return f.Parse(f.Defaults)
+}
+
+func newField(name string, fieldType FieldType, required bool, defaultValues []string) *Field {
+	return &Field{
+		Name:     name,
+		Type:     fieldType,
+		Required: required,
+		Defaults: defaultValues,
 	}
 }

--- a/pkg/runtimes/runtime_test.go
+++ b/pkg/runtimes/runtime_test.go
@@ -1,0 +1,136 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Builder_Spec(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		setup func() *Builder
+		spec  *adagio.Node_Spec
+	}{
+		{
+			name: "happy path",
+			setup: func() *Builder {
+				var (
+					builder      = NewBuilder("foo")
+					stringField  = "a_string"
+					stringsField = []string{"a", "b", "c"}
+					int64Field   = int64(12345)
+				)
+
+				builder.String("string_field", false, "")(&stringField)
+				builder.Strings("strings_field", false)(&stringsField)
+				builder.Int64("int64_field", false, 0)(&int64Field)
+
+				return builder
+			},
+			spec: &adagio.Node_Spec{
+				Runtime: "foo",
+				Metadata: map[string]*adagio.MetadataValue{
+					"adagio.runtime.foo.string_field": &adagio.MetadataValue{
+						Values: []string{"a_string"},
+					},
+					"adagio.runtime.foo.strings_field": &adagio.MetadataValue{
+						Values: []string{"a", "b", "c"},
+					},
+					"adagio.runtime.foo.int64_field": &adagio.MetadataValue{
+						Values: []string{"12345"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			b := testCase.setup()
+
+			spec, err := b.Spec()
+			assert.Nil(t, err)
+
+			assert.Equal(t, testCase.spec, spec)
+		})
+	}
+}
+
+func Test_Builder_Parse(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		spec  *adagio.Node_Spec
+		setup func() (*Builder, func(*testing.T))
+	}{
+		{
+			name: "happy path",
+			spec: &adagio.Node_Spec{
+				Name:    "a",
+				Runtime: "foo",
+				Metadata: map[string]*adagio.MetadataValue{
+					"adagio.runtime.foo.string_field": &adagio.MetadataValue{
+						Values: []string{"a_string"},
+					},
+					"adagio.runtime.foo.strings_field": &adagio.MetadataValue{
+						Values: []string{"a", "b", "c"},
+					},
+					"adagio.runtime.foo.int64_field": &adagio.MetadataValue{
+						Values: []string{"12345"},
+					},
+				},
+			},
+			setup: func() (*Builder, func(*testing.T)) {
+				var (
+					builder      = NewBuilder("foo")
+					stringField  string
+					stringsField []string
+					int64Field   int64
+				)
+
+				builder.String("string_field", false, "")(&stringField)
+				builder.Strings("strings_field", false)(&stringsField)
+				builder.Int64("int64_field", false, 0)(&int64Field)
+
+				return builder, func(t *testing.T) {
+					assert.Equal(t, "a_string", stringField)
+					assert.Equal(t, []string{"a", "b", "c"}, stringsField)
+					assert.Equal(t, int64(12345), int64Field)
+				}
+			},
+		},
+		{
+			name: "happy path - defaults",
+			spec: &adagio.Node_Spec{
+				Name:     "a",
+				Runtime:  "foo",
+				Metadata: map[string]*adagio.MetadataValue{},
+			},
+			setup: func() (*Builder, func(*testing.T)) {
+				var (
+					builder      = NewBuilder("foo")
+					stringField  string
+					stringsField []string
+					int64Field   int64
+				)
+
+				builder.String("string_field", false, "other_string")(&stringField)
+				builder.Strings("strings_field", false, "c", "d", "e")(&stringsField)
+				builder.Int64("int64_field", false, 20)(&int64Field)
+
+				return builder, func(t *testing.T) {
+					assert.Equal(t, "other_string", stringField)
+					assert.Equal(t, []string{"c", "d", "e"}, stringsField)
+					assert.Equal(t, int64(20), int64Field)
+				}
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			builder, assert := testCase.setup()
+
+			builder.Parse(testCase.spec)
+
+			assert(t)
+		})
+	}
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -162,11 +162,12 @@ func (p *Pool) handleEvent(claimer Claimer, event *adagio.Event) error {
 	switch event.Type {
 	case adagio.Event_NODE_READY:
 		var result *adagio.Result
-		result, err = runtime.Run(node)
-		nodeResult = &adagio.Node_Result{
-			Conclusion: adagio.Node_Result_Conclusion(result.Conclusion),
-			Metadata:   result.Metadata,
-			Output:     result.Output,
+		if result, err = runtime.Run(node); err == nil {
+			nodeResult = &adagio.Node_Result{
+				Conclusion: adagio.Node_Result_Conclusion(result.Conclusion),
+				Metadata:   result.Metadata,
+				Output:     result.Output,
+			}
 		}
 
 	case adagio.Event_NODE_ORPHANED:

--- a/pkg/workflow/doc.go
+++ b/pkg/workflow/doc.go
@@ -1,0 +1,50 @@
+//	package main
+//
+//	import (
+//		"context"
+//
+//		"github.com/georgemac/adagio/pkg/adagio"
+//		"github.com/georgemac/adagio/pkg/rpc/controlplane"
+//		"github.com/georgemac/adagio/pkg/runtimes/debug"
+//		"github.com/georgemac/adagio/pkg/runtimes/exec"
+//		"github.com/georgemac/adagio/pkg/workflow"
+//	)
+//
+//  // start creates, configures and runs the following graph workflow:
+//  // (a) ---> (c)----
+//  //   \             \
+//  //    ------v       v
+//  //         (d) --> (e) --> (g)
+//  //    ------^               ^
+//  //   /                     /
+//  // (b) --> (f) ------------
+//  // Node (d) is configured to panic 50% of the time with up to 3 attempts on this kind of system error
+//  // Node (g) is configured to ls / on the running agent
+//	func start(ctxt context.Context, client controlplane.ControlPlaneClient) (*adagio.Run, error) {
+//		var (
+//			success        = debug.NewCall(adagio.Result_SUCCESS)
+//			potentialPanic = debug.NewCall(adagio.Result_SUCCESS,
+//				debug.With(debug.Chance(0.5, debug.Panic)))
+//
+//			runLS   = exec.NewCall("ls", "/")
+//
+//			builder = workflow.NewBuilder()
+//			a       = MustNode(builder.Node("a", success))
+//			b       = MustNode(builder.Node("b", success))
+//			c       = MustNode(builder.Node("c", success))
+//			d       = MustNode(builder.Node("d", potentialPanic, workflow.WithRetry(adagio.OnError, 3)))
+//			e       = MustNode(builder.Node("e", success))
+//			f       = MustNode(builder.Node("f", success))
+//			g       = MustNode(builder.Node("g", runLS))
+//		)
+//
+//		c.DependsOn(a)
+//		d.DependsOn(a, b)
+//		f.DependsOn(b)
+//		e.DependsOn(c, d)
+//		g.DependsOn(e, f)
+//
+//		return builder.Start(ctxt, client)
+//	}
+//
+package workflow

--- a/pkg/workflow/support_test.go
+++ b/pkg/workflow/support_test.go
@@ -1,0 +1,34 @@
+package workflow
+
+import (
+	"context"
+
+	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/rpc/controlplane"
+	"google.golang.org/grpc"
+)
+
+func spec(s *adagio.Node_Spec) Specer {
+	return SpecerFunc(func() (*adagio.Node_Spec, error) {
+		return s, nil
+	})
+}
+
+type SpecerFunc func() (*adagio.Node_Spec, error)
+
+func (s SpecerFunc) Spec() (*adagio.Node_Spec, error) {
+	return s()
+}
+
+type client struct {
+	controlplane.ControlPlaneClient
+
+	req  *controlplane.StartRequest
+	resp *controlplane.StartResponse
+}
+
+func (c *client) Start(ctx context.Context, in *controlplane.StartRequest, opts ...grpc.CallOption) (*controlplane.StartResponse, error) {
+	c.req = in
+
+	return c.resp, nil
+}

--- a/pkg/workflow/workflow.go
+++ b/pkg/workflow/workflow.go
@@ -1,0 +1,108 @@
+package workflow
+
+import (
+	"context"
+
+	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/rpc/controlplane"
+)
+
+// Specer is any type which can produce an adagio Node_Spec
+// pointer
+type Specer interface {
+	Spec() (*adagio.Node_Spec, error)
+}
+
+// Option is a functional option for a node spec
+type Option func(*adagio.Node_Spec)
+
+// Options is a slice of Option types
+type Options []Option
+
+// Apply calls each option in turn on the provided Node_Spec
+func (o Options) Apply(spec *adagio.Node_Spec) {
+	for _, opt := range o {
+		opt(spec)
+	}
+}
+
+// WithRetry configures a retry for a specified condition up to
+// maxAttempts times on a Node_Spec
+func WithRetry(condition adagio.RetryCondition, maxAttempts int32) Option {
+	return func(spec *adagio.Node_Spec) {
+		if spec.Retry == nil {
+			spec.Retry = map[string]*adagio.Node_Spec_Retry{}
+		}
+
+		spec.Retry[string(condition)] = &adagio.Node_Spec_Retry{MaxAttempts: maxAttempts}
+	}
+}
+
+// Builder is a type used to compose calls to start runs on a client
+// It can be used to convert runtime calls into workflow nodes
+// configure connections between nodes and then invoke the
+// built graph spec onto a client which produces a new Run
+type Builder struct {
+	spec *adagio.GraphSpec
+}
+
+// NewBuilder creates and configures a new Builder
+func NewBuilder() Builder {
+	return Builder{spec: &adagio.GraphSpec{}}
+}
+
+// MustNode panics if err is nil otherwise it returns the provided node
+func MustNode(n Node, err error) Node {
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// Node creates a node from a provided name and Specer type
+// it also applies any provided options
+func (b Builder) Node(name string, s Specer, opts ...Option) (n Node, err error) {
+	spec, err := s.Spec()
+	if err != nil {
+		return Node{}, err
+	}
+
+	spec.Name = name
+
+	n = Node{builder: b, spec: spec}
+
+	Options(opts).Apply(n.spec)
+
+	b.spec.Nodes = append(b.spec.Nodes, n.spec)
+
+	return
+}
+
+// Start invokes the built graph specification onto the provided client
+// It returns the run responded by the controlplane API
+func (b Builder) Start(ctx context.Context, client controlplane.ControlPlaneClient) (*adagio.Run, error) {
+	resp, err := client.Start(ctx, &controlplane.StartRequest{Spec: b.spec})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Run, nil
+}
+
+// Node is a builder wrapper type which can be used to further
+// create connections between nodes in the originating builder
+type Node struct {
+	builder Builder
+	spec    *adagio.Node_Spec
+}
+
+// DependsOn creates a connection from the provided nodes (sources)
+// to the callee node (destination) on the original builder
+func (n Node) DependsOn(nodes ...Node) {
+	for _, v := range nodes {
+		n.builder.spec.Edges = append(n.builder.spec.Edges, &adagio.Edge{
+			Source:      v.spec.Name,
+			Destination: n.spec.Name,
+		})
+	}
+}

--- a/pkg/workflow/workflow_test.go
+++ b/pkg/workflow/workflow_test.go
@@ -1,0 +1,64 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/rpc/controlplane"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Builder_Simple(t *testing.T) {
+	var (
+		aSpec = &adagio.Node_Spec{Name: "a"}
+		bSpec = &adagio.Node_Spec{Name: "b"}
+		cSpec = &adagio.Node_Spec{
+			Name: "c",
+			Retry: map[string]*adagio.Node_Spec_Retry{
+				"fail": &adagio.Node_Spec_Retry{MaxAttempts: 2},
+			},
+		}
+		dSpec = &adagio.Node_Spec{Name: "d"}
+
+		emptySpec = SpecerFunc(func() (*adagio.Node_Spec, error) {
+			return &adagio.Node_Spec{}, nil
+		})
+
+		expected = &adagio.Run{Id: "foo"}
+		resp     = &controlplane.StartResponse{Run: expected}
+		client   = &client{resp: resp}
+
+		expectedGraphSpec = &adagio.GraphSpec{
+			Nodes: []*adagio.Node_Spec{
+				aSpec,
+				bSpec,
+				cSpec,
+				dSpec,
+			},
+			Edges: []*adagio.Edge{
+				{Source: "a", Destination: "c"},
+				{Source: "b", Destination: "c"},
+				{Source: "c", Destination: "d"},
+			},
+		}
+	)
+
+	var (
+		builder = NewBuilder()
+
+		a = MustNode(builder.Node("a", emptySpec))
+		b = MustNode(builder.Node("b", emptySpec))
+		c = MustNode(builder.Node("c", emptySpec, WithRetry(adagio.OnFail, 2)))
+		d = MustNode(builder.Node("d", emptySpec))
+	)
+
+	c.DependsOn(a, b)
+	d.DependsOn(c)
+
+	run, err := builder.Start(context.Background(), client)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, run)
+	assert.Equal(t, expectedGraphSpec, client.req.Spec)
+}


### PR DESCRIPTION
Closes #15 

This introduces the new `workflow` package and additional concrete `runtime` package helper types.

It removes the older anonymous function demo runtimes and collates them into a single helpful `runtime/debug`  package. This new package offers similar behaviour to the original sample runtimes like "panic" and "echo". However, it is not a single "debug" runtime with lots of configurable options to get the same desired effect.

This also introduces the new `workflows` builders. These builders can convert types which produce node specs (`Spec() (*adagio.Node_Spec, error)` see `runtimes.Builder` for the helper type to create these) into nodes which have helpful `DependsOn()` function to create connections between nodes. The builder can then over a start call onto a client and return the corresponding run which is received.