### PR TITLE
Switch to using etcd namespace package

### DIFF
--- a/pkg/etcd/options.go
+++ b/pkg/etcd/options.go
@@ -1,17 +1,30 @@
 package etcd
 
+// Option is a functional option for repository
 type Option func(*Repository)
 
+// Options is a slice of Option
 type Options []Option
 
+// Apply calls each option on r in turn
 func (o Options) Apply(r *Repository) {
 	for _, opt := range o {
 		opt(r)
 	}
 }
 
+// ForList constructs a repository client for a specific
+// list (other than the default one)
+func ForList(name string) Option {
+	return func(r *Repository) {
+		r.list = name
+	}
+}
+
+// WithNamespace configures the etcd client to use a particular
+// top-level prefix
 func WithNamespace(ns string) Option {
 	return func(r *Repository) {
-		r.ns = namespace(ns)
+		r.namespace = ns
 	}
 }


### PR DESCRIPTION
Now that we have upgraded to use etcd v3.4.3 the etcd `namespace` package is available without having to mess around with prefixing and stripping bytes. This simplifies things.

I also introduced the concept of a list in the `etcd` repository. This is an experiment and just an extra configurable prefix for now. Going to consider making it a first class citzen.