### PR TITLE
Thread context through all the things

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1,4 +1,4 @@
-package worker
+package agent
 
 import (
 	"context"
@@ -79,7 +79,7 @@ type ClaimerFunc func() *adagio.Claim
 // NewClaim delegates to underlying ClaimerFunc
 func (fn ClaimerFunc) NewClaim() *adagio.Claim { return fn() }
 
-// Pool spins up a number of worker goroutines which subscribe to nodes
+// Pool spins up a number of agent goroutines which subscribe to nodes
 // transitioning into the ready state and then attempts to claim and
 // process them
 type Pool struct {
@@ -113,7 +113,7 @@ func NewPool(repo Repository, runtimes RuntimeMap, opts ...Option) *Pool {
 	return pool
 }
 
-// Run begins the configured number of workers and responds to cancelation
+// Run begins the configured number of agents and responds to cancelation
 // of the supplied context
 func (p *Pool) Run(ctxt context.Context) {
 	var (

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,4 +1,4 @@
-package worker
+package agent
 
 import (
 	"context"
@@ -51,7 +51,7 @@ func TestPool_HappyPath_NODE_READY(t *testing.T) {
 			})
 		}
 
-		pool = NewPool(&repo, RuntimeMap(runtimes), WithWorkerCount(5), WithClaimerFunc(claimFunc))
+		pool = NewPool(&repo, RuntimeMap(runtimes), WithAgentCount(5), WithClaimerFunc(claimFunc))
 
 		done         = make(chan struct{})
 		ctxt, cancel = context.WithCancel(context.Background())
@@ -142,7 +142,7 @@ func TestPool_Error_RuntimeDoesNotExist(t *testing.T) {
 				return claim
 			})
 		}
-		pool = NewPool(&repo, runtimes, WithWorkerCount(5), WithClaimerFunc(claimFunc))
+		pool = NewPool(&repo, runtimes, WithAgentCount(5), WithClaimerFunc(claimFunc))
 
 		done         = make(chan struct{})
 		ctxt, cancel = context.WithCancel(context.Background())
@@ -227,7 +227,7 @@ func TestPool_Error_RuntimeError(t *testing.T) {
 				return claim
 			})
 		}
-		pool = NewPool(&repo, runtimes, WithWorkerCount(5), WithClaimerFunc(claimFunc))
+		pool = NewPool(&repo, runtimes, WithAgentCount(5), WithClaimerFunc(claimFunc))
 
 		done         = make(chan struct{})
 		ctxt, cancel = context.WithCancel(context.Background())
@@ -318,7 +318,7 @@ func TestPool_Error_NODE_ORPHANED(t *testing.T) {
 				return claim
 			})
 		}
-		pool = NewPool(&repo, runtimes, WithWorkerCount(5), WithClaimerFunc(claimFunc))
+		pool = NewPool(&repo, runtimes, WithAgentCount(5), WithClaimerFunc(claimFunc))
 
 		done         = make(chan struct{})
 		ctxt, cancel = context.WithCancel(context.Background())

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -27,7 +27,7 @@ func TestPool_HappyPath_NODE_READY(t *testing.T) {
 				name: "test",
 				newFunction: func() Function {
 					return function{
-						run: func(n *adagio.Node) (*adagio.Result, error) {
+						run: func(_ context.Context, n *adagio.Node) (*adagio.Result, error) {
 							atomic.AddUint64(&runCalls, 1)
 
 							require.Equal(t, n, node)
@@ -119,7 +119,7 @@ func TestPool_Error_RuntimeDoesNotExist(t *testing.T) {
 				name: "known",
 				newFunction: func() Function {
 					return function{
-						run: func(n *adagio.Node) (*adagio.Result, error) {
+						run: func(_ context.Context, n *adagio.Node) (*adagio.Result, error) {
 							atomic.AddUint64(&runCalls, 1)
 
 							require.Equal(t, n, node)
@@ -206,7 +206,7 @@ func TestPool_Error_RuntimeError(t *testing.T) {
 				name: "error",
 				newFunction: func() Function {
 					return function{
-						run: func(n *adagio.Node) (*adagio.Result, error) {
+						run: func(_ context.Context, n *adagio.Node) (*adagio.Result, error) {
 							atomic.AddUint64(&runCalls, 1)
 
 							require.Equal(t, n, node)
@@ -295,7 +295,7 @@ func TestPool_Error_NODE_ORPHANED(t *testing.T) {
 				name: "test",
 				newFunction: func() Function {
 					return function{
-						run: func(n *adagio.Node) (*adagio.Result, error) {
+						run: func(_ context.Context, n *adagio.Node) (*adagio.Result, error) {
 							atomic.AddUint64(&runCalls, 1)
 
 							require.Equal(t, n, node)

--- a/pkg/agent/options.go
+++ b/pkg/agent/options.go
@@ -1,4 +1,4 @@
-package worker
+package agent
 
 type Option func(*Pool)
 
@@ -10,7 +10,7 @@ func (o Options) Apply(p *Pool) {
 	}
 }
 
-func WithWorkerCount(count int) Option {
+func WithAgentCount(count int) Option {
 	return func(p *Pool) {
 		p.size = count
 	}

--- a/pkg/agent/support_test.go
+++ b/pkg/agent/support_test.go
@@ -1,4 +1,4 @@
-package worker
+package agent
 
 import (
 	"sync"

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -12,16 +12,16 @@ import (
 	"time"
 
 	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/agent"
 	"github.com/georgemac/adagio/pkg/graph"
 	"github.com/georgemac/adagio/pkg/service/controlplane"
-	"github.com/georgemac/adagio/pkg/worker"
 	"github.com/oklog/ulid"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/namespace"
 )
 
 var (
-	_ worker.Repository       = (*Repository)(nil)
+	_ agent.Repository        = (*Repository)(nil)
 	_ controlplane.Repository = (*Repository)(nil)
 
 	minULID = ulid.MustNew(0, zeroReader{})
@@ -613,7 +613,7 @@ func (r *Repository) Subscribe(a *adagio.Agent, events chan<- *adagio.Event, typ
 		return err
 	}
 
-	if _, err := r.kv.Put(context.Background(), agent(a), string(agentData), clientv3.WithLease(leaseID)); err != nil {
+	if _, err := r.kv.Put(context.Background(), agentKey(a), string(agentData), clientv3.WithLease(leaseID)); err != nil {
 		return err
 	}
 
@@ -897,7 +897,7 @@ func (r *Repository) UnsubscribeAll(a *adagio.Agent, ch chan<- *adagio.Event) er
 	defer r.mu.Unlock()
 
 	// delete agent key before the
-	_, err := r.kv.Delete(context.Background(), agent(a))
+	_, err := r.kv.Delete(context.Background(), agentKey(a))
 	if err != nil {
 		return err
 	}
@@ -914,7 +914,7 @@ func (r *Repository) UnsubscribeAll(a *adagio.Agent, ch chan<- *adagio.Event) er
 	return nil
 }
 
-func agent(agent *adagio.Agent) string {
+func agentKey(agent *adagio.Agent) string {
 	return agentsPrefix + agent.Id
 }
 

--- a/pkg/memory/repository.go
+++ b/pkg/memory/repository.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"math"
 	"sort"
 	"sync"
@@ -55,7 +56,7 @@ func New() *Repository {
 	}
 }
 
-func (r *Repository) Stats() (*adagio.Stats, error) {
+func (r *Repository) Stats(context.Context) (*adagio.Stats, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -82,7 +83,7 @@ func (r *Repository) Stats() (*adagio.Stats, error) {
 	}, nil
 }
 
-func (r *Repository) StartRun(spec *adagio.GraphSpec) (run *adagio.Run, err error) {
+func (r *Repository) StartRun(_ context.Context, spec *adagio.GraphSpec) (run *adagio.Run, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -110,7 +111,7 @@ func (r *Repository) StartRun(spec *adagio.GraphSpec) (run *adagio.Run, err erro
 	return
 }
 
-func (r *Repository) InspectRun(id string) (*adagio.Run, error) {
+func (r *Repository) InspectRun(_ context.Context, id string) (*adagio.Run, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -143,7 +144,7 @@ func (r *Repository) InspectRun(id string) (*adagio.Run, error) {
 	return run, nil
 }
 
-func (r *Repository) ListAgents() (agents []*adagio.Agent, err error) {
+func (r *Repository) ListAgents(_ context.Context) (agents []*adagio.Agent, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -158,7 +159,7 @@ func (r *Repository) ListAgents() (agents []*adagio.Agent, err error) {
 	return
 }
 
-func (r *Repository) ListRuns(req controlplane.ListRequest) (runs []*adagio.Run, err error) {
+func (r *Repository) ListRuns(_ context.Context, req controlplane.ListRequest) (runs []*adagio.Run, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -224,7 +225,7 @@ func (r *Repository) ListRuns(req controlplane.ListRequest) (runs []*adagio.Run,
 	return
 }
 
-func (r *Repository) ClaimNode(runID, name string, claim *adagio.Claim) (*adagio.Node, bool, error) {
+func (r *Repository) ClaimNode(_ context.Context, runID, name string, claim *adagio.Claim) (*adagio.Node, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -270,7 +271,7 @@ func (r *Repository) notifyReady(run *adagio.Run, node *adagio.Node) {
 	}
 }
 
-func (r *Repository) FinishNode(runID, name string, result *adagio.Node_Result, claim *adagio.Claim) error {
+func (r *Repository) FinishNode(_ context.Context, runID, name string, result *adagio.Node_Result, claim *adagio.Claim) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -374,7 +375,7 @@ func (r *Repository) handleFailure(state runState, node *adagio.Node, src map[gr
 	return nil
 }
 
-func (r *Repository) Subscribe(agent *adagio.Agent, events chan<- *adagio.Event, types ...adagio.Event_Type) error {
+func (r *Repository) Subscribe(_ context.Context, agent *adagio.Agent, events chan<- *adagio.Event, types ...adagio.Event_Type) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -400,7 +401,7 @@ func (r *Repository) Subscribe(agent *adagio.Agent, events chan<- *adagio.Event,
 	return nil
 }
 
-func (r *Repository) UnsubscribeAll(agent *adagio.Agent, events chan<- *adagio.Event) error {
+func (r *Repository) UnsubscribeAll(_ context.Context, agent *adagio.Agent, events chan<- *adagio.Event) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/pkg/memory/repository.go
+++ b/pkg/memory/repository.go
@@ -7,15 +7,15 @@ import (
 	"time"
 
 	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/agent"
 	"github.com/georgemac/adagio/pkg/graph"
 	"github.com/georgemac/adagio/pkg/service/controlplane"
-	"github.com/georgemac/adagio/pkg/worker"
 	"github.com/pkg/errors"
 )
 
 var (
-	// compile time check to ensure Repository is a worker.Repository
-	_ worker.Repository       = (*Repository)(nil)
+	// compile time check to ensure Repository is a agent.Repository
+	_ agent.Repository        = (*Repository)(nil)
 	_ controlplane.Repository = (*Repository)(nil)
 )
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/agent"
 	"github.com/georgemac/adagio/pkg/service/controlplane"
-	"github.com/georgemac/adagio/pkg/worker"
 	"github.com/kr/pretty"
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
@@ -68,7 +68,7 @@ var (
 
 type Repository interface {
 	controlplane.Repository
-	worker.Repository
+	agent.Repository
 }
 
 type Orphaner interface {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -89,7 +90,10 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("a run is created", func(t *testing.T) {
-		run, err := repo.StartRun(ExampleGraph)
+		var (
+			ctx      = context.Background()
+			run, err = repo.StartRun(ctx, ExampleGraph)
+		)
 		require.Nil(t, err)
 		require.NotNil(t, run)
 
@@ -217,11 +221,11 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 				RunStatus: adagio.Run_COMPLETED,
 			},
 		} {
-			layer.Exec(t)
+			layer.Exec(t, ctx)
 		}
 
 		t.Run("the run is listed", func(t *testing.T) {
-			runs, err := repo.ListRuns(controlplane.ListRequest{})
+			runs, err := repo.ListRuns(ctx, controlplane.ListRequest{})
 			require.Nil(t, err)
 
 			assert.Len(t, runs, 1)
@@ -253,7 +257,10 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("a run with a failure", func(t *testing.T) {
-		run, err := repo.StartRun(ExampleGraph)
+		var (
+			ctx      = context.Background()
+			run, err = repo.StartRun(ctx, ExampleGraph)
+		)
 		require.Nil(t, err)
 		require.NotNil(t, run)
 
@@ -328,11 +335,11 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 				RunStatus: adagio.Run_COMPLETED,
 			},
 		} {
-			layer.Exec(t)
+			layer.Exec(t, ctx)
 		}
 
 		t.Run("the run is listed", func(t *testing.T) {
-			runs, err := repo.ListRuns(controlplane.ListRequest{})
+			runs, err := repo.ListRuns(ctx, controlplane.ListRequest{})
 			require.Nil(t, err)
 
 			// the run is listed
@@ -363,23 +370,26 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("a run with retries", func(t *testing.T) {
-		// (a) --> (h) --> (c)
-		//                  ^
-		//                 /
-		//         (b) ----
-		run, err := repo.StartRun(&adagio.GraphSpec{
-			Nodes: []*adagio.Node_Spec{
-				a,
-				b,
-				c,
-				h,
-			},
-			Edges: []*adagio.Edge{
-				{Source: a.Name, Destination: h.Name},
-				{Source: b.Name, Destination: c.Name},
-				{Source: h.Name, Destination: c.Name},
-			},
-		})
+		var (
+			ctx = context.Background()
+			// (a) --> (h) --> (c)
+			//                  ^
+			//                 /
+			//         (b) ----
+			run, err = repo.StartRun(ctx, &adagio.GraphSpec{
+				Nodes: []*adagio.Node_Spec{
+					a,
+					b,
+					c,
+					h,
+				},
+				Edges: []*adagio.Edge{
+					{Source: a.Name, Destination: h.Name},
+					{Source: b.Name, Destination: c.Name},
+					{Source: h.Name, Destination: c.Name},
+				},
+			})
+		)
 		require.Nil(t, err)
 		require.NotNil(t, run)
 
@@ -487,11 +497,11 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 				RunStatus: adagio.Run_COMPLETED,
 			},
 		} {
-			layer.Exec(t)
+			layer.Exec(t, ctx)
 		}
 
 		t.Run("the run is listed", func(t *testing.T) {
-			runs, err := repo.ListRuns(controlplane.ListRequest{})
+			runs, err := repo.ListRuns(ctx, controlplane.ListRequest{})
 			require.Nil(t, err)
 
 			// the run is listed
@@ -513,23 +523,26 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("a run with exhausted retries", func(t *testing.T) {
-		// (a) --> (i) --> (c)
-		//                  ^
-		//                 /
-		//         (b) ----
-		run, err := repo.StartRun(&adagio.GraphSpec{
-			Nodes: []*adagio.Node_Spec{
-				a,
-				b,
-				c,
-				i,
-			},
-			Edges: []*adagio.Edge{
-				{Source: a.Name, Destination: i.Name},
-				{Source: b.Name, Destination: c.Name},
-				{Source: i.Name, Destination: c.Name},
-			},
-		})
+		var (
+			ctx = context.Background()
+			// (a) --> (i) --> (c)
+			//                  ^
+			//                 /
+			//         (b) ----
+			run, err = repo.StartRun(ctx, &adagio.GraphSpec{
+				Nodes: []*adagio.Node_Spec{
+					a,
+					b,
+					c,
+					i,
+				},
+				Edges: []*adagio.Edge{
+					{Source: a.Name, Destination: i.Name},
+					{Source: b.Name, Destination: c.Name},
+					{Source: i.Name, Destination: c.Name},
+				},
+			})
+		)
 		require.Nil(t, err)
 		require.NotNil(t, run)
 
@@ -612,11 +625,11 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 				RunStatus: adagio.Run_COMPLETED,
 			},
 		} {
-			layer.Exec(t)
+			layer.Exec(t, ctx)
 		}
 
 		t.Run("the run is listed", func(t *testing.T) {
-			runs, err := repo.ListRuns(controlplane.ListRequest{})
+			runs, err := repo.ListRuns(ctx, controlplane.ListRequest{})
 			require.Nil(t, err)
 
 			// the run is listed
@@ -637,13 +650,16 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("a run with an orphaned node", func(t *testing.T) {
-		// (a)
-		run, err := repo.StartRun(&adagio.GraphSpec{
-			Nodes: []*adagio.Node_Spec{
-				a,
-			},
-			Edges: []*adagio.Edge{},
-		})
+		var (
+			ctx = context.Background()
+			// (a)
+			run, err = repo.StartRun(ctx, &adagio.GraphSpec{
+				Nodes: []*adagio.Node_Spec{
+					a,
+				},
+				Edges: []*adagio.Edge{},
+			})
+		)
 		require.Nil(t, err)
 		require.NotNil(t, run)
 
@@ -652,7 +668,7 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 			events = make(chan *adagio.Event, 5)
 		)
 
-		err = repo.Subscribe(agent, events, adagio.Event_NODE_READY, adagio.Event_NODE_ORPHANED)
+		err = repo.Subscribe(ctx, agent, events, adagio.Event_NODE_READY, adagio.Event_NODE_ORPHANED)
 		require.Nil(t, err)
 
 		assert.Equal(t, adagio.Run_WAITING, run.Status)
@@ -669,7 +685,7 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 		var claims map[string]*adagio.Claim
 		t.Run("an initial claim is made", func(t *testing.T) {
 			// ensure node can initially be claimed
-			claims = canClaim(t, repo, run, map[string]*adagio.Node{"a": running(a, nil)})
+			claims = canClaim(t, ctx, repo, run, map[string]*adagio.Node{"a": running(a, nil)})
 		})
 
 		// orphan claim for node "a" from run
@@ -685,16 +701,16 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 
 		t.Run("the orphaned node", func(t *testing.T) {
 			// ensure orphaned node can be claimed again and has no results yet
-			claims = canClaim(t, repo, run, map[string]*adagio.Node{"a": running(a, nil)})
+			claims = canClaim(t, ctx, repo, run, map[string]*adagio.Node{"a": running(a, nil)})
 		})
 
 		// can error the node
-		canFinish(t, repo, run, map[string]adagio.Node_Result_Conclusion{
+		canFinish(t, ctx, repo, run, map[string]adagio.Node_Result_Conclusion{
 			"a": adagio.Node_Result_ERROR,
 		}, claims)
 
 		t.Run("the run is listed", func(t *testing.T) {
-			runs, err := repo.ListRuns(controlplane.ListRequest{})
+			runs, err := repo.ListRuns(ctx, controlplane.ListRequest{})
 			require.Nil(t, err)
 
 			// the run is listed
@@ -708,7 +724,7 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("a call to stats reports as expected", func(t *testing.T) {
-		stats, err := repo.Stats()
+		stats, err := repo.Stats(context.Background())
 		require.Nil(t, err)
 
 		assert.Equal(t, &adagio.Stats{
@@ -720,7 +736,10 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 	})
 
 	t.Run("list runs with predicates", func(t *testing.T) {
-		allRuns, err := repo.ListRuns(controlplane.ListRequest{})
+		var (
+			ctx          = context.Background()
+			allRuns, err = repo.ListRuns(ctx, controlplane.ListRequest{})
+		)
 		require.Nil(t, err)
 		require.Len(t, allRuns, 5)
 
@@ -773,7 +792,7 @@ func TestHarness(t *testing.T, repoFn Constructor) {
 			},
 		} {
 			t.Run(test.name, func(t *testing.T) {
-				runs, err := repo.ListRuns(test.req)
+				runs, err := repo.ListRuns(ctx, test.req)
 				assert.Nil(t, err)
 
 				assert.Equal(t, test.runs, runs)
@@ -793,35 +812,35 @@ type TestLayer struct {
 	RunStatus   adagio.Run_Status
 }
 
-func (l *TestLayer) Exec(t *testing.T) {
+func (l *TestLayer) Exec(t *testing.T, ctx context.Context) {
 	t.Helper()
 
 	var (
 		agent     = &adagio.Agent{Id: "foo"}
 		events    = make(chan *adagio.Event, len(l.Events))
 		collected = make([]*adagio.Event, 0)
-		err       = l.Repository.Subscribe(agent, events, adagio.Event_NODE_READY)
+		err       = l.Repository.Subscribe(ctx, agent, events, adagio.Event_NODE_READY)
 	)
 	require.Nil(t, err)
 
 	defer func() {
-		l.Repository.UnsubscribeAll(agent, events)
+		l.Repository.UnsubscribeAll(ctx, agent, events)
 
 		close(events)
 	}()
 
 	var claims map[string]*adagio.Claim
 	t.Run(l.Name, func(t *testing.T) {
-		canNotClaim(t, l.Repository, l.Run, l.Unclaimable...)
+		canNotClaim(t, ctx, l.Repository, l.Run, l.Unclaimable...)
 
-		claims = canClaim(t, l.Repository, l.Run, l.Claimable)
+		claims = canClaim(t, ctx, l.Repository, l.Run, l.Claimable)
 	})
 
-	canFinish(t, l.Repository, l.Run, l.Finish, claims)
+	canFinish(t, ctx, l.Repository, l.Run, l.Finish, claims)
 
 	t.Run(fmt.Sprintf("the run is reported with a status of %q", l.RunStatus), func(t *testing.T) {
 		// check run reports expected status
-		run, err := l.Repository.InspectRun(l.Run.Id)
+		run, err := l.Repository.InspectRun(ctx, l.Run.Id)
 		require.Nil(t, err)
 		require.Equal(t, l.RunStatus, run.Status)
 	})
@@ -848,7 +867,7 @@ func (l *TestLayer) Exec(t *testing.T) {
 	}
 
 	t.Run("the subscribed agent is listed", func(t *testing.T) {
-		agents, err := l.Repository.ListAgents()
+		agents, err := l.Repository.ListAgents(ctx)
 		require.Nil(t, err)
 		require.Len(t, agents, 1)
 
@@ -856,7 +875,7 @@ func (l *TestLayer) Exec(t *testing.T) {
 	})
 }
 
-func canNotClaim(t *testing.T, repo Repository, run *adagio.Run, names ...string) {
+func canNotClaim(t *testing.T, ctx context.Context, repo Repository, run *adagio.Run, names ...string) {
 	t.Helper()
 
 	t.Run("can not claim", func(t *testing.T) {
@@ -867,7 +886,7 @@ func canNotClaim(t *testing.T, repo Repository, run *adagio.Run, names ...string
 				func(name string) {
 					t.Parallel()
 
-					_, _, err := repo.ClaimNode(run.Id, name, newClaim())
+					_, _, err := repo.ClaimNode(ctx, run.Id, name, newClaim())
 					assert.Equal(t, adagio.ErrNodeNotReady, errors.Cause(err))
 				}(name)
 			})
@@ -875,7 +894,7 @@ func canNotClaim(t *testing.T, repo Repository, run *adagio.Run, names ...string
 	})
 }
 
-func canClaim(t *testing.T, repo Repository, run *adagio.Run, nodes map[string]*adagio.Node) (claims map[string]*adagio.Claim) {
+func canClaim(t *testing.T, ctx context.Context, repo Repository, run *adagio.Run, nodes map[string]*adagio.Node) (claims map[string]*adagio.Claim) {
 	t.Helper()
 
 	var mu sync.Mutex
@@ -889,7 +908,7 @@ func canClaim(t *testing.T, repo Repository, run *adagio.Run, nodes map[string]*
 				func(name string, node *adagio.Node) {
 					t.Parallel()
 
-					claimed, claim := attemptNClaims(t, repo, run, name, 5)
+					claimed, claim := attemptNClaims(t, ctx, repo, run, name, 5)
 					node.Claim = claim
 
 					t.Run("and it returns the correct node", func(t *testing.T) {
@@ -907,7 +926,7 @@ func canClaim(t *testing.T, repo Repository, run *adagio.Run, nodes map[string]*
 	return
 }
 
-func canFinish(t *testing.T, repo Repository, run *adagio.Run, names map[string]adagio.Node_Result_Conclusion, claims map[string]*adagio.Claim) {
+func canFinish(t *testing.T, ctx context.Context, repo Repository, run *adagio.Run, names map[string]adagio.Node_Result_Conclusion, claims map[string]*adagio.Claim) {
 	t.Helper()
 
 	t.Run("can finish", func(t *testing.T) {
@@ -919,7 +938,7 @@ func canFinish(t *testing.T, repo Repository, run *adagio.Run, names map[string]
 				func(name string, conclusion adagio.Node_Result_Conclusion, claim *adagio.Claim) {
 					t.Parallel()
 
-					assert.Nil(t, repo.FinishNode(run.Id, name, &adagio.Node_Result{
+					assert.Nil(t, repo.FinishNode(ctx, run.Id, name, &adagio.Node_Result{
 						Conclusion: conclusion,
 						Output:     []byte(name),
 					}, claim))
@@ -929,7 +948,7 @@ func canFinish(t *testing.T, repo Repository, run *adagio.Run, names map[string]
 	})
 }
 
-func attemptNClaims(t *testing.T, repo Repository, run *adagio.Run, name string, n int) (node *adagio.Node, claim *adagio.Claim) {
+func attemptNClaims(t *testing.T, ctx context.Context, repo Repository, run *adagio.Run, name string, n int) (node *adagio.Node, claim *adagio.Claim) {
 	t.Helper()
 
 	t.Run("only one successful claim is made", func(t *testing.T) {
@@ -945,7 +964,7 @@ func attemptNClaims(t *testing.T, repo Repository, run *adagio.Run, name string,
 				defer wg.Done()
 				var (
 					cclaim         = newClaim()
-					cnode, ok, err = repo.ClaimNode(run.Id, name, cclaim)
+					cnode, ok, err = repo.ClaimNode(ctx, run.Id, name, cclaim)
 				)
 				require.Nil(t, err)
 

--- a/pkg/runtimes/debug/debug.go
+++ b/pkg/runtimes/debug/debug.go
@@ -1,6 +1,7 @@
 package debug
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -125,7 +126,7 @@ func With(chances ...ChanceCondition) Option {
 // then loops over any provided chance conditions.
 // Given no chance condinition is met it returns the configured
 // adagio result conclusion
-func (function *Function) Run() (*adagio.Result, error) {
+func (function *Function) Run(ctx context.Context) (*adagio.Result, error) {
 	time.Sleep(time.Duration(function.Sleep))
 
 	for _, c := range function.Chances {

--- a/pkg/runtimes/debug/debug.go
+++ b/pkg/runtimes/debug/debug.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/agent"
 	runtime "github.com/georgemac/adagio/pkg/runtimes"
-	"github.com/georgemac/adagio/pkg/worker"
 	"github.com/georgemac/adagio/pkg/workflow"
 )
 
@@ -20,8 +20,8 @@ var (
 )
 
 // Runtime returns the debub packages runtime
-func Runtime() worker.Runtime {
-	return worker.RuntimeFunc(name, func() worker.Function {
+func Runtime() agent.Runtime {
+	return agent.RuntimeFunc(name, func() agent.Function {
 		return runtime.Function(blankFunction())
 	})
 }

--- a/pkg/runtimes/doc.go
+++ b/pkg/runtimes/doc.go
@@ -1,12 +1,12 @@
 // The runtime package contains types which aid in the building of runtimes
-// and runtime calls which can be constructed and invoked by the worker types.
+// and runtime calls which can be constructed and invoked by the agent types.
 //
 // The *Builder type aids in composing types which avoid having to do manual
 // parsing to and from metadata fields on adagio.Node types.
 //
 // The `runtime.Function()` is a handy function which takes a type with the behavior for
 // parsing an incoming node (`Parse(*adagio.Node) error`) and running the function once
-// parsed (`Run() (*adagio.Result, error)`) as separate calls and combines them in a worker.Function
+// parsed (`Run() (*adagio.Result, error)`) as separate calls and combines them in a agent.Function
 // compatible implementation.
 // This allows for a *runtime.Builder to be embedded into new Function definitions,
 // which can then take on the responsibility of the `Parse(node) error` call.
@@ -21,7 +21,7 @@
 //
 // package thing
 //
-// import "github.com/georgemac/adagio/pkg/worker"
+// import "github.com/georgemac/adagio/pkg/agent"
 //
 // const name = "thing"
 //
@@ -29,7 +29,7 @@
 //
 // func (r Runtime) Name() string { return name }
 //
-// func (r Runtime) BlankFunction() worker.Function {
+// func (r Runtime) BlankFunction() agent.Function {
 //     return runtime.Function(blankFunction())
 // }
 //

--- a/pkg/runtimes/exec/exec.go
+++ b/pkg/runtimes/exec/exec.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"os/exec"
 
 	"github.com/georgemac/adagio/pkg/adagio"
@@ -50,7 +51,7 @@ func NewFunction(command string, args ...string) *Function {
 
 // Run spawns a subprocess for the desired command and returns the combined
 // output writer as an adagio Result output slice of bytes
-func (fn *Function) Run() (*adagio.Result, error) {
+func (fn *Function) Run(context.Context) (*adagio.Result, error) {
 	data, err := exec.Command(fn.Command, fn.Args...).CombinedOutput()
 	if err != nil {
 		return nil, err

--- a/pkg/runtimes/exec/exec.go
+++ b/pkg/runtimes/exec/exec.go
@@ -4,8 +4,8 @@ import (
 	"os/exec"
 
 	"github.com/georgemac/adagio/pkg/adagio"
+	"github.com/georgemac/adagio/pkg/agent"
 	runtime "github.com/georgemac/adagio/pkg/runtimes"
-	"github.com/georgemac/adagio/pkg/worker"
 	"github.com/georgemac/adagio/pkg/workflow"
 )
 
@@ -15,9 +15,9 @@ var (
 	_ workflow.Function = (*Function)(nil)
 )
 
-// Runtime returns the exec package worker.Runtime
-func Runtime() worker.Runtime {
-	return worker.RuntimeFunc(name, func() worker.Function {
+// Runtime returns the exec package agent.Runtime
+func Runtime() agent.Runtime {
+	return agent.RuntimeFunc(name, func() agent.Function {
 		return runtime.Function(blankFunction())
 	})
 }
@@ -31,7 +31,7 @@ func blankFunction() *Function {
 	return c
 }
 
-// Function is a struct which implements the worker.Runtime
+// Function is a struct which implements the agent.Runtime
 // It executes the work for a provided node on a function to Run
 // and uses the os/exec package to invoke a subprocess
 type Function struct {

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -55,7 +55,7 @@ type ParseRunner interface {
 }
 
 // FunctionAdaptor is the type used to covert a ParseRunner
-// into a worker.Function compatable type
+// into a agent.Function compatable type
 type FunctionAdaptor struct {
 	runner ParseRunner
 }
@@ -70,7 +70,7 @@ func (p FunctionAdaptor) Run(n *adagio.Node) (*adagio.Result, error) {
 	return p.runner.Run()
 }
 
-// Function converts the provided ParseRunner into a worker.Function
+// Function converts the provided ParseRunner into a agent.Function
 // using the FunctionAdaptor wrapper type
 func Function(runner ParseRunner) FunctionAdaptor {
 	return FunctionAdaptor{runner}

--- a/pkg/runtimes/runtime.go
+++ b/pkg/runtimes/runtime.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,7 +52,7 @@ const (
 // and then invoking the desired behavior via Run
 type ParseRunner interface {
 	Parse(n *adagio.Node) error
-	Run() (*adagio.Result, error)
+	Run(ctx context.Context) (*adagio.Result, error)
 }
 
 // FunctionAdaptor is the type used to covert a ParseRunner
@@ -62,12 +63,12 @@ type FunctionAdaptor struct {
 
 // Run calls Parse on the provided node and then invokes
 // Run on the underlying ParseRunner
-func (p FunctionAdaptor) Run(n *adagio.Node) (*adagio.Result, error) {
+func (p FunctionAdaptor) Run(ctx context.Context, n *adagio.Node) (*adagio.Result, error) {
 	if err := p.runner.Parse(n); err != nil {
 		return nil, err
 	}
 
-	return p.runner.Run()
+	return p.runner.Run(ctx)
 }
 
 // Function converts the provided ParseRunner into a agent.Function

--- a/pkg/service/controlplane/server.go
+++ b/pkg/service/controlplane/server.go
@@ -12,11 +12,11 @@ import (
 var _ controlplane.ControlPlaneServer = (*Service)(nil)
 
 type Repository interface {
-	Stats() (*adagio.Stats, error)
-	StartRun(*adagio.GraphSpec) (*adagio.Run, error)
-	InspectRun(id string) (*adagio.Run, error)
-	ListRuns(ListRequest) ([]*adagio.Run, error)
-	ListAgents() ([]*adagio.Agent, error)
+	Stats(context.Context) (*adagio.Stats, error)
+	StartRun(context.Context, *adagio.GraphSpec) (*adagio.Run, error)
+	InspectRun(ctx context.Context, id string) (*adagio.Run, error)
+	ListRuns(context.Context, ListRequest) ([]*adagio.Run, error)
+	ListAgents(context.Context) ([]*adagio.Agent, error)
 }
 
 type ListRequest struct {
@@ -37,8 +37,8 @@ func New(repo Repository) *Service {
 	return s
 }
 
-func (s *Service) Stats(_ context.Context, req *controlplane.StatsRequest) (*controlplane.StatsResponse, error) {
-	stats, err := s.repo.Stats()
+func (s *Service) Stats(ctx context.Context, req *controlplane.StatsRequest) (*controlplane.StatsResponse, error) {
+	stats, err := s.repo.Stats(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +46,8 @@ func (s *Service) Stats(_ context.Context, req *controlplane.StatsRequest) (*con
 	return &controlplane.StatsResponse{Stats: stats}, nil
 }
 
-func (s *Service) Start(_ context.Context, req *controlplane.StartRequest) (*controlplane.StartResponse, error) {
-	run, err := s.repo.StartRun(req.Spec)
+func (s *Service) Start(ctx context.Context, req *controlplane.StartRequest) (*controlplane.StartResponse, error) {
+	run, err := s.repo.StartRun(ctx, req.Spec)
 	if err != nil {
 		return nil, errors.Wrap(err, "control plane: starting run")
 	}
@@ -55,8 +55,8 @@ func (s *Service) Start(_ context.Context, req *controlplane.StartRequest) (*con
 	return &controlplane.StartResponse{Run: run}, nil
 }
 
-func (s *Service) Inspect(_ context.Context, req *controlplane.InspectRequest) (*controlplane.InspectResponse, error) {
-	run, err := s.repo.InspectRun(req.Id)
+func (s *Service) Inspect(ctx context.Context, req *controlplane.InspectRequest) (*controlplane.InspectResponse, error) {
+	run, err := s.repo.InspectRun(ctx, req.Id)
 	if err != nil {
 		return nil, errors.Wrap(err, "control plane: starting run")
 	}
@@ -64,7 +64,7 @@ func (s *Service) Inspect(_ context.Context, req *controlplane.InspectRequest) (
 	return &controlplane.InspectResponse{Run: run}, nil
 }
 
-func (s *Service) ListRuns(_ context.Context, r *controlplane.ListRequest) (*controlplane.ListRunsResponse, error) {
+func (s *Service) ListRuns(ctx context.Context, r *controlplane.ListRequest) (*controlplane.ListRunsResponse, error) {
 	req := ListRequest{
 		Limit: &r.Limit,
 	}
@@ -79,7 +79,7 @@ func (s *Service) ListRuns(_ context.Context, r *controlplane.ListRequest) (*con
 		req.Finish = &until
 	}
 
-	runs, err := s.repo.ListRuns(req)
+	runs, err := s.repo.ListRuns(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "control plane: listing runs")
 	}
@@ -87,8 +87,8 @@ func (s *Service) ListRuns(_ context.Context, r *controlplane.ListRequest) (*con
 	return &controlplane.ListRunsResponse{Runs: runs}, nil
 }
 
-func (s *Service) ListAgents(_ context.Context, _ *controlplane.ListRequest) (*controlplane.ListAgentsResponse, error) {
-	agents, err := s.repo.ListAgents()
+func (s *Service) ListAgents(ctx context.Context, _ *controlplane.ListRequest) (*controlplane.ListAgentsResponse, error) {
+	agents, err := s.repo.ListAgents(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "control place: listing agents")
 	}


### PR DESCRIPTION
Long time coming.
1. Threaded context.Context through all the things.
2. Renamed `worker` package to `agent`